### PR TITLE
Add default_language_version` to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_language_version:
+  python: python3
+
 repos:
 
   -   repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Resolves issue with Python 3.10 being recognized as 3.1.