### PR TITLE
Removed 3.8 from CI test suite and add 3.11

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - python=3.8
+  - python=3.9
   - xmltodict
   - xsdata
   - xarray


### PR DESCRIPTION
- Remove 3.8 from CI tests
- Add 3.11 to CI tests
- Build docs using 3.9
