### PR TITLE
Enh/manage groups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       -   id: check-yaml
       -   id: double-quote-string-fixer
 
-  -   repo: https://github.com/psf/black
+  -   repo: https://github.com/psf/black-pre-commit-mirror
       rev: 23.12.1
       hooks:
       - id: black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+0.5.0 (unreleased)
+==================
+
+**Breaking changes**
+- Nested group handling:
+  Before this version, all groups were read, but conflicting variable names in-between groups would be cause a lost of data.
+  Now, similarly to xarray ``open_dataset``, ``open_ncml`` accepts an optional `group` argument to specify which group should be read.
+  When ``group`` is missing, the root group is assumed.
+  Additionally ``group`` can be set to ``'*'``. In that case every group is read and the hierachy is flatten.
+  In the event of conflicting names, the variable/dimension name will be updated by appending '__n' where n is incremented.
+
+
 0.4.0 (2024-01-08)
 ==================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,7 @@
 
 **Breaking changes**
 - Nested group handling:
-  Before this version, all groups were read, but conflicting variable names in-between groups would be cause a lost of data.
-  Now, similarly to xarray ``open_dataset``, ``open_ncml`` accepts an optional `group` argument to specify which group should be read.
-  When ``group`` is missing, the root group is assumed.
-  Additionally ``group`` can be set to ``'*'``. In that case every group is read and the hierachy is flatten.
-  In the event of conflicting names, the variable/dimension name will be updated by appending '__n' where n is incremented.
+  Before this version, all groups were read, but conflicting variable names in-between groups would shadow data.  Now, similarly to xarray ``open_dataset``, ``open_ncml`` accepts an optional ``group`` argument to specify which group should be read. When ``group`` is not specified, it defaults to the root group. Additionally ``group`` can be set to ``'*'`` so that every group is read and the hierarchy is flattened.   In the event of conflicting variable/dimension names across groups, the conflicting name will be modified by appending ``'__n'`` where n is incremented.
 
 
 0.4.0 (2024-01-08)

--- a/tests/data/testGroup.xml
+++ b/tests/data/testGroup.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
     <variable name="toto" shape="" type="ushort">
+        <values>3</values>
     </variable>
     <group name="a_sub_group">
-        <variable name="group_var" shape="" type="ushort"></variable>
+        <variable name="group_var" shape="" type="ushort">
+            <values>1</values>
+        </variable>
     </group>
     <group name="another_sub_group">
-        <variable name="other_group_var" shape="" type="ushort"></variable>
+        <variable name="other_group_var" shape="" type="ushort">
+            <values>2</values>
+        </variable>
     </group>
 </netcdf>

--- a/tests/data/testGroup.xml
+++ b/tests/data/testGroup.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+    <variable name="toto" shape="" type="ushort">
+    </variable>
+    <group name="a_sub_group">
+        <variable name="group_var" shape="" type="ushort"></variable>
+    </group>
+    <group name="another_sub_group">
+        <variable name="other_group_var" shape="" type="ushort"></variable>
+    </group>
+</netcdf>

--- a/tests/data/testGroupConflictingDims.xml
+++ b/tests/data/testGroupConflictingDims.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+    <group name="gr_a">
+        <dimension name="index" length="42"/>
+        <variable name="gr_a_var" shape="index" type="ushort"></variable>
+    </group>
+    <group name="gr_b">
+        <dimension name="index" length="94"/>
+        <variable name="gr_b_var" shape="index" type="ushort"></variable>
+    </group>
+</netcdf>

--- a/tests/data/testGroupInvalidDim.xml
+++ b/tests/data/testGroupInvalidDim.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+    <variable name="toto" shape="myDim" type="ushort">
+        <values>3</values>
+    </variable>
+    <dimension name="myDim"></dimension>
+</netcdf>

--- a/tests/data/testGroupMultiLayers.xml
+++ b/tests/data/testGroupMultiLayers.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+    <variable name="a_var" shape="" type="ushort">
+        <values>2</values>
+    </variable>
     <group name="gr_a">
         <dimension name="index" length="42"/>
         <group name="sub_gr">
-            <variable name="gr_a_var" shape="index" type="ushort"></variable>
+            <variable name="a_var" shape="index" type="ushort"></variable>
         </group>
     </group>
     <group name="gr_b">
         <dimension name="index" length="22"/>
         <group name="sub_gr">
-            <variable name="gr_b_var" shape="index" type="ushort"></variable>
+            <variable name="a_var" shape="index" type="ushort"></variable>
         </group>
     </group>
 </netcdf>

--- a/tests/data/testGroupMultiLayers.xml
+++ b/tests/data/testGroupMultiLayers.xml
@@ -2,8 +2,14 @@
 <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
     <group name="gr_a">
         <dimension name="index" length="42"/>
-        <group name="sub_gr_a">
+        <group name="sub_gr">
             <variable name="gr_a_var" shape="index" type="ushort"></variable>
+        </group>
+    </group>
+    <group name="gr_b">
+        <dimension name="index" length="22"/>
+        <group name="sub_gr">
+            <variable name="gr_b_var" shape="index" type="ushort"></variable>
         </group>
     </group>
 </netcdf>

--- a/tests/data/testGroupMultiLayers.xml
+++ b/tests/data/testGroupMultiLayers.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+    <group name="gr_a">
+        <dimension name="index" length="42"/>
+        <group name="sub_gr_a">
+            <variable name="gr_a_var" shape="index" type="ushort"></variable>
+        </group>
+    </group>
+</netcdf>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -360,14 +360,37 @@ def test_read_group__read_sub_group():
     assert ds.get('other_group_var') is None
 
 
+def test_read_group__conflicting_dims():
+    """Read a group and ensure its dimension is correct"""
+    ds = xncml.open_ncml(data / 'testGroupConflictingDims.xml', group='gr_b')
+    assert ds.dims['index'] == 94
+    assert 'index' in ds.gr_b_var.dims
+
+
 def test_flatten_groups():
     """Read every group and flatten everything in a single dataset/group."""
     ds = xncml.open_ncml(data / 'testGroup.xml', group='*')
     assert ds.toto is not None
+    assert ds.get('toto__1') is None
     assert ds.get('group_var') is not None
     ds.group_var.attrs['group_path'] = '/a_sub_group'
     assert ds.get('other_group_var') is not None
     ds.other_group_var.attrs['group_path'] = '/another_sub_group'
+
+
+def test_flatten_groups__conflicting_dims():
+    """Read every group and rename dimensions"""
+    ds = xncml.open_ncml(data / 'testGroupConflictingDims.xml', group='*')
+    assert 'index' in ds.gr_a_var.dims
+    assert ds.dims['index'] is not None
+    assert 'index__1' in ds.gr_b_var.dims
+    assert ds.dims['index__1'] is not None
+
+
+def test_flatten_groups__sub_groups():
+    """Read every group and rename dimensions"""
+    ds = xncml.open_ncml(data / 'testGroupMultiLayers.xml', group='*')
+    assert ds.dims['index'] is not None
 
 
 # --- #

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -395,9 +395,12 @@ def test_flatten_groups__conflicting_dims():
 def test_flatten_groups__sub_groups():
     """Read every group and rename dimensions"""
     ds = xncml.open_ncml(data / 'testGroupMultiLayers.xml', group='*')
-    assert ds.dims['index'] is not None
-    assert ds['gr_a_var'] is not None
-    assert ds['gr_b_var'] is not None
+    assert ds.dims['index'] == 42
+    assert ds.dims['index__1'] == 22
+    assert ds['a_var'].size == 1
+    assert ds['a_var'] == 2
+    assert ds['a_var__1'].size == 42
+    assert ds['a_var__2'].size == 22
 
 
 # --- #

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -310,8 +310,8 @@ def test_unsigned_type():
 
 def test_empty_scalar__no_values_tag():
     """
-    A scalar without a <values> tag will not be typed, even if the 'type' attribute is
-    filled, because numpy can't create an empty typed scalar.
+    A scalar variable which <values> is missing will have its value set to
+    the default value of its type.
     """
     ds = xncml.open_ncml(data / 'testEmptyScalar.xml')
     assert ds['empty_scalar_var'].dtype == np.dtype('float64')
@@ -319,13 +319,13 @@ def test_empty_scalar__no_values_tag():
 
 
 def test_empty_scalar__with_empty_values_tag():
-    """A scalar with an empty in its <values> tag is invalid."""
+    """A scalar with an empty <values> tag is invalid."""
     with pytest.raises(ValueError, match='No values found for variable .*'):
         xncml.open_ncml(data / 'testEmptyScalar_withValuesTag.xml')
 
 
 def test_multiple_values_for_scalar():
-    """a scalar with multiple values in its <values> tag is invalid."""
+    """A scalar with multiple values in its <values> tag is invalid."""
     with pytest.raises(ValueError, match='The expected size for variable .* was 1, .*'):
         xncml.open_ncml(data / 'testEmptyScalar_withMultipleValues.xml')
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -310,8 +310,8 @@ def test_unsigned_type():
 
 def test_empty_scalar__no_values_tag():
     """
-    Scalar without values loose their type because we can't create a typed numpy
-    scalar which is empty
+    A scalar without a <values> tag will not be typed, even if the 'type' attribute is
+    filled, because numpy can't create an empty typed scalar.
     """
     ds = xncml.open_ncml(data / 'testEmptyScalar.xml')
     assert ds['empty_scalar_var'].dtype == np.dtype('O')
@@ -319,13 +319,13 @@ def test_empty_scalar__no_values_tag():
 
 
 def test_empty_scalar__with_empty_values_tag():
-    """A scalar variable with an empty <values> tag is invalid."""
+    """A scalar with an empty in its <values> tag is invalid."""
     with pytest.raises(ValueError, match='No values found for variable .*'):
         xncml.open_ncml(data / 'testEmptyScalar_withValuesTag.xml')
 
 
 def test_multiple_values_for_scalar():
-    """Scalar with an multiple values in <values> tag is invalid."""
+    """a scalar with multiple values in its <values> tag is invalid."""
     with pytest.raises(ValueError, match='The expected size for variable .* was 1, .*'):
         xncml.open_ncml(data / 'testEmptyScalar_withMultipleValues.xml')
 
@@ -341,6 +341,33 @@ def test_empty_attr():
     """A empty attribute is valid."""
     ds = xncml.open_ncml(data / 'testEmptyAttr.xml')
     assert ds.attrs['comment'] == ''
+
+
+def test_read_group__read_only_root_group():
+    """By default, only read root group."""
+    ds = xncml.open_ncml(data / 'testGroup.xml')
+    assert ds.toto is not None
+    assert ds.get('group_var') is None
+    assert ds.get('other_group_var') is None
+
+
+def test_read_group__read_sub_group():
+    """Read specified sub group and its parents."""
+    ds = xncml.open_ncml(data / 'testGroup.xml', group='a_sub_group')
+    assert ds.toto is not None
+    assert ds.get('group_var') is not None
+    ds.group_var.attrs['group_path'] = '/a_sub_group'
+    assert ds.get('other_group_var') is None
+
+
+def test_flatten_groups():
+    """Read every group and flatten everything in a single dataset/group."""
+    ds = xncml.open_ncml(data / 'testGroup.xml', group='*')
+    assert ds.toto is not None
+    assert ds.get('group_var') is not None
+    ds.group_var.attrs['group_path'] = '/a_sub_group'
+    assert ds.get('other_group_var') is not None
+    ds.other_group_var.attrs['group_path'] = '/another_sub_group'
 
 
 # --- #

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -367,6 +367,11 @@ def test_read_group__conflicting_dims():
     assert 'index' in ds.gr_b_var.dims
 
 
+def test_read__invalid_dim():
+    with pytest.raises(ValueError, match="Unknown dimension 'myDim'.*"):
+        xncml.open_ncml(data / 'testGroupInvalidDim.xml')
+
+
 def test_flatten_groups():
     """Read every group and flatten everything in a single dataset/group."""
     ds = xncml.open_ncml(data / 'testGroup.xml', group='*')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -314,8 +314,8 @@ def test_empty_scalar__no_values_tag():
     filled, because numpy can't create an empty typed scalar.
     """
     ds = xncml.open_ncml(data / 'testEmptyScalar.xml')
-    assert ds['empty_scalar_var'].dtype == np.dtype('O')
-    assert ds['empty_scalar_var'].item() is None
+    assert ds['empty_scalar_var'].dtype == np.dtype('float64')
+    assert ds['empty_scalar_var'].item() == 0
 
 
 def test_empty_scalar__with_empty_values_tag():
@@ -396,6 +396,8 @@ def test_flatten_groups__sub_groups():
     """Read every group and rename dimensions"""
     ds = xncml.open_ncml(data / 'testGroupMultiLayers.xml', group='*')
     assert ds.dims['index'] is not None
+    assert ds['gr_a_var'] is not None
+    assert ds['gr_b_var'] is not None
 
 
 # --- #

--- a/xncml/parser.py
+++ b/xncml/parser.py
@@ -354,16 +354,6 @@ def read_group(
     return target
 
 
-def _build_snake_name(prefix: str, suffix: str) -> str:
-    if prefix == ROOT_GROUP:
-        pre = ''
-    else:
-        pre = prefix.removeprefix('/')
-        pre = pre.replace('/', '_')
-        pre += '_'
-    return f'{pre}{suffix}'
-
-
 def read_scan(obj: Aggregation.Scan, ncml: Path) -> list[xr.Dataset]:
     """
     Return list of datasets defined in <scan> element.

--- a/xncml/parser.py
+++ b/xncml/parser.py
@@ -60,7 +60,7 @@ from .generated import (
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-__author__ = 'David Huard'
+__author__ = 'David Huard, Abel Aoun'
 __date__ = 'July 2022'
 __contact__ = 'huard.david@ouranos.ca'
 
@@ -96,7 +96,7 @@ def open_ncml(ncml: str | Path, group: str = ROOT_GROUP) -> xr.Dataset:
       Path to NcML file.
     group : str
       Path of the group to parse within the ncml.
-      The special value ``*`` opens every group and flatten the variables into a single
+      The special value ``*`` opens every group and flattens the variables into a single
       dataset, renaming variables and dimensions if conflicting names are found.
 
     Returns
@@ -129,7 +129,7 @@ def read_netcdf(
       Path to NcML document, sometimes required to follow relative links.
     group : str
       Path of the group to parse within the ncml.
-      The special value ``*`` opens every group and flatten the variables into a single
+      The special value ``*`` opens every group and flattens the variables into a single
       dataset.
 
     Returns
@@ -488,9 +488,9 @@ def read_variable(
     dimensions : dict
       Dimension attributes keyed by name.
     enums: dict[str, dict]
-      The enums types that have been read in the upper groups.
+      The enums types that have been read in the parent groups.
     group_path: str
-      Path to the parent group
+      Path to the parent group.
 
     Returns
     -------

--- a/xncml/parser.py
+++ b/xncml/parser.py
@@ -534,7 +534,6 @@ def read_variable(
         shape = []
         for dim in obj.shape.split(' '):
             if dimensions.get(dim) is None:
-                # TODO: Add test for this branch, might be useless.
                 err = (
                     f"Unknown dimension '{dim}'."
                     ' Make sure it is declared before being used in the NCML.'
@@ -589,10 +588,6 @@ def read_variable(
         raise NotImplementedError
 
     var_name = obj.name
-    # TODO (abel): Fix for aggregation: we must override the variable and not create a new one in aggregation case
-    #               How to differentiate this case with variables in different groups that bear the same name ?
-    #               Should we carry a flag `override` from read_aggregation ?
-    #               Or when a flag to know we are in sub-groups ?
     if (
         (existing_var := target.get(var_name)) is not None
         and existing_var.attrs.get('group_path')

--- a/xncml/parser.py
+++ b/xncml/parser.py
@@ -86,7 +86,7 @@ def parse(path: Path) -> Netcdf:
     return parser.from_path(path, Netcdf)
 
 
-def open_ncml(ncml: str | Path, group: str = '/') -> xr.Dataset:
+def open_ncml(ncml: str | Path, group: str = ROOT_GROUP) -> xr.Dataset:
     """
     Convert NcML document to a dataset.
 
@@ -227,7 +227,7 @@ def read_aggregation(target: xr.Dataset, obj: Aggregation, ncml: Path) -> xr.Dat
     else:
         raise NotImplementedError
 
-    agg = read_group(agg, ref=None, obj=obj, groups_to_read=['/'])
+    agg = read_group(agg, ref=None, obj=obj, groups_to_read=[ROOT_GROUP])
     out = target.merge(agg, combine_attrs='no_conflicts')
     out.set_close(partial(_multi_file_closer, closers))
     return out
@@ -283,7 +283,7 @@ def read_group(
     ref: xr.Dataset | None,
     obj: Group | Netcdf,
     groups_to_read: list[str],
-    parent_group_path: str = '/',
+    parent_group_path: str = ROOT_GROUP,
     dims: dict = None,
     enums: dict = None,
 ) -> xr.Dataset:
@@ -311,6 +311,7 @@ def read_group(
     dims = {} if dims is None else dims
     enums = {} if enums is None else enums
     for item in obj.choice:
+
         if isinstance(item, Dimension):
             dim_name = item.name
             if dims.get(dim_name):


### PR DESCRIPTION
- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.

This PR fixes #64 
- This adds an optional `group` argument to `open_ncml`
- When present, only the given group of the ncml will be read.
- When absent, the root group `'/'` is read.
The above is similar to xarray's `open_dataset`.

In addition, using `group='*'`, it flattens every group into a single datasets (somewhat preserving the current behavior). 
The names conflicts between groups are solved by appending an incrementing `__n` to the variable names, where n is a number.
Plus, an attribute `group_path` is added to variables in order to retrieve their original path once they have been flatten.
This can be useful to recreate the original structure.