### PR TITLE
FIX: #70 scalar parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   Before this version, all groups were read, but conflicting variable names in-between groups would shadow data.  Now, similarly to xarray ``open_dataset``, ``open_ncml`` accepts an optional ``group`` argument to specify which group should be read. When ``group`` is not specified, it defaults to the root group. Additionally ``group`` can be set to ``'*'`` so that every group is read and the hierarchy is flattened.   In the event of conflicting variable/dimension names across groups, the conflicting name will be modified by appending ``'__n'`` where n is incremented.
 - Enums are no longer transformed into CF flag_values and flag_meanings attributes, instead they are stored in the ``encoding["dtype"].metadata`` of their respective variable. This is aligned with what is done on xarray v2024.01.0
 
+- [fix] scalar attributes that are not strings are no longer wrapped in a tuple of length 1.
+
 0.4.0 (2024-01-08)
 ==================
 
@@ -13,7 +15,7 @@
 - Update XSD schema and dataclasses to latest version from netcdf-java to add support
   for unsigned types. By @bzah
 - Add support for scalar variables. By @Bzah
-- [fix] empty attributes now are parsed into an empty string instead of crashing the parser.  By @Bzah
+- [fix] empty attributes are now parsed into an empty string instead of crashing the parser.  By @Bzah
 
 0.3.1 (2023-11-10)
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 0.5.0 (unreleased)
 ==================
 
-**Breaking changes**
+Breaking changes
+^^^^^^^^^^^^^^^^
+
 - Nested group handling:
   Before this version, all groups were read, but conflicting variable names in-between groups would shadow data.  Now, similarly to xarray ``open_dataset``, ``open_ncml`` accepts an optional ``group`` argument to specify which group should be read. When ``group`` is not specified, it defaults to the root group. Additionally ``group`` can be set to ``'*'`` so that every group is read and the hierarchy is flattened.   In the event of conflicting variable/dimension names across groups, the conflicting name will be modified by appending ``'__n'`` where n is incremented.
 - Enums are no longer transformed into CF flag_values and flag_meanings attributes, instead they are stored in the ``encoding["dtype"].metadata`` of their respective variable. This is aligned with what is done on xarray v2024.01.0
-
-- [fix] scalar attributes that are not strings are no longer wrapped in a tuple of length 1.
+- [fix] scalar attributes that are not strings are no longer wrapped in tuples of length 1.
 
 0.4.0 (2024-01-08)
 ==================

--- a/tests/data/testDoubleAttr.xml
+++ b/tests/data/testDoubleAttr.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+    <attribute name="toto" type="double" value="42.42" />
+    <attribute name="comment" value="" />
+</netcdf>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -403,6 +403,11 @@ def test_flatten_groups__sub_groups():
     assert ds['a_var__2'].size == 22
 
 
+def test_read_non_str_attribute():
+    ds = xncml.open_ncml(data / 'testDoubleAttr.xml')
+    assert ds.attrs['toto'] == 42.42
+
+
 # --- #
 def check_dimension(ds):
     assert len(ds['lat']) == 3

--- a/xncml/parser.py
+++ b/xncml/parser.py
@@ -779,9 +779,10 @@ def cast(obj: Attribute) -> tuple | str:
     if value:
         if obj.type in [DataType.STRING, DataType.STRING_1]:
             return value
-
         sep = obj.separator or ' '
         values = value.split(sep)
+        if len(values) == 1:
+            return nctype(obj.type)(values[0])
         return tuple(map(nctype(obj.type), values))
     return ''
 


### PR DESCRIPTION
- [ ] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.

[summarize your pull request here]

Fix #70, scalars attributes are no longer wrapped in tuples.